### PR TITLE
Update AchievementUnlocked.java for Android 8.0

### DIFF
--- a/app/src/main/java/net/darkion/achievementUnlockedApp/AchievementUnlocked.java
+++ b/app/src/main/java/net/darkion/achievementUnlockedApp/AchievementUnlocked.java
@@ -265,7 +265,7 @@ public class AchievementUnlocked {
             if (mainViewLP == null) {
                 mainViewLP = new WindowManager.LayoutParams(
                         WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT,
-                        WindowManager.LayoutParams.TYPE_SYSTEM_ERROR, focusable
+                        WindowOverlayCompat.TYPE_SYSTEM_ERROR, focusable
                         ,
                         PixelFormat.TRANSLUCENT);
             }
@@ -1575,4 +1575,12 @@ class DeceleratingInterpolator implements TimeInterpolator {
     public float getInterpolation(float t) {
         return computeLog(t, mBase) * mLogScale;
     }
+}
+
+class WindowOverlayCompat {
+    private static final int ANDROID_OREO = 26;
+    private static final int TYPE_APPLICATION_OVERLAY = 2038;
+
+    static final int TYPE_SYSTEM_ERROR = Build.VERSION.SDK_INT < ANDROID_OREO ? WindowManager.LayoutParams.TYPE_SYSTEM_ERROR : TYPE_APPLICATION_OVERLAY;
+  
 }


### PR DESCRIPTION
WindowManager.LayoutParams.TYPE_SYSTEM_ERROR was deprecated in API Level 26 for non-system apps; I fixed it buy using WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY for API 26 and WindowManager.LayoutParams.TYPE_SYSTEM_ERROR for everthing else